### PR TITLE
Use Megaparsec 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Stache 0.3.0
+## Stache 1.0.0
 
 * Improved metadata and documentation.
 
@@ -6,6 +6,13 @@
   when referenced key is not provided as per the spec. This is the behaviour
   we had before 0.2.0, and it played better with the rest of Mustache.
   Correspondingly, `MustacheRenderException` was removed.
+
+* Stache now uses Megaparsec 6 for parsing.
+
+* `MustacheException` now includes original input as `Text`.
+
+* `compileMustacheText` and `parseMustache` now accept strict `Text` instead
+  of lazy `Text`.
 
 ## Stache 0.2.2
 

--- a/Text/Mustache/Compile/TH.hs
+++ b/Text/Mustache/Compile/TH.hs
@@ -28,7 +28,7 @@ where
 
 import Control.Exception (Exception(..))
 import Control.Monad.Catch (try)
-import Data.Text.Lazy (Text)
+import Data.Text (Text)
 import Data.Typeable (cast)
 import Language.Haskell.TH hiding (Dec)
 import Language.Haskell.TH.Quote (QuasiQuoter (..))
@@ -36,7 +36,6 @@ import Language.Haskell.TH.Syntax (lift, addDependentFile)
 import System.Directory
 import Text.Mustache.Type
 import qualified Data.Text             as T
-import qualified Data.Text.Lazy        as TL
 import qualified Text.Mustache.Compile as C
 
 #if !MIN_VERSION_base(4,8,0)
@@ -86,7 +85,7 @@ compileMustacheText
   -> Text              -- ^ The template to compile
   -> Q Exp
 compileMustacheText pname text =
-  (handleEither . either (Left . MustacheParserException) Right)
+  (handleEither . either (Left . MustacheParserException text) Right)
   (C.compileMustacheText pname text)
 
 -- | Compile Mustache using QuasiQuoter. Usage:
@@ -105,7 +104,7 @@ compileMustacheText pname text =
 
 mustache :: QuasiQuoter
 mustache = QuasiQuoter
-  { quoteExp  = compileMustacheText "quasi-quoted" . TL.pack
+  { quoteExp  = compileMustacheText "quasi-quoted" . T.pack
   , quotePat  = undefined
   , quoteType = undefined
   , quoteDec  = undefined }

--- a/Text/Mustache/Type.hs
+++ b/Text/Mustache/Type.hs
@@ -34,6 +34,7 @@ import Data.Semigroup
 import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Typeable (Typeable)
+import Data.Void
 import GHC.Generics
 import Text.Megaparsec
 import qualified Data.Map  as M
@@ -108,7 +109,7 @@ instance NFData PName
 -- values are not provided.
 
 data MustacheException
-  = MustacheParserException (ParseError Char Dec)
+  = MustacheParserException Text (ParseError Char Void)
     -- ^ Template parser has failed. This contains the parse error.
     --
     -- /Before version 0.2.0 it was called 'MustacheException'./
@@ -116,7 +117,7 @@ data MustacheException
 
 #if MIN_VERSION_base(4,8,0)
 instance Exception MustacheException where
-  displayException (MustacheParserException e) = parseErrorPretty e
+  displayException (MustacheParserException s e) = parseErrorPretty' s e
 #else
 instance Exception MustacheException
 #endif

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -13,7 +13,7 @@ import Text.Mustache.Compile
 import Text.Mustache.Parser
 import Text.Mustache.Render
 import Text.Mustache.Type
-import qualified Data.Text.Lazy.IO as T
+import qualified Data.Text.IO as T
 
 ----------------------------------------------------------------------------
 -- Benchmarks

--- a/mustache-spec/Spec.hs
+++ b/mustache-spec/Spec.hs
@@ -38,9 +38,9 @@ data Test = Test
   { testName     :: String
   , testDesc     :: String
   , testData     :: Value
-  , testTemplate :: TL.Text
-  , testExpected :: TL.Text
-  , testPartials :: Map Text TL.Text
+  , testTemplate :: Text
+  , testExpected :: Text
+  , testPartials :: Map Text Text
   }
 
 instance FromJSON Test where
@@ -84,5 +84,5 @@ specData aspect bytes = describe aspect $ do
                   Left perr -> handleError perr >> undefined
                   Right ns  -> return (pname, ns)
               let ps2 = M.fromList ps1 `M.union` templateCache
-              renderMustache (Template templateActual ps2) testData
+              TL.toStrict (renderMustache (Template templateActual ps2) testData)
                 `shouldBe` testExpected

--- a/stache.cabal
+++ b/stache.cabal
@@ -36,7 +36,7 @@ library
                     , directory        >= 1.2  && < 1.4
                     , exceptions       >= 0.8  && < 0.9
                     , filepath         >= 1.2  && < 1.5
-                    , megaparsec       >= 5.0  && < 6.0
+                    , megaparsec       >= 6.0  && < 7.0
                     , mtl              >= 2.1  && < 3.0
                     , template-haskell >= 2.10 && < 2.13
                     , text             >= 1.2  && < 1.3
@@ -64,8 +64,8 @@ test-suite tests
                     , base             >= 4.7  && < 5.0
                     , containers       >= 0.5  && < 0.6
                     , hspec            >= 2.0  && < 3.0
-                    , hspec-megaparsec >= 0.2  && < 0.4
-                    , megaparsec       >= 5.0  && < 6.0
+                    , hspec-megaparsec >= 1.0  && < 2.0
+                    , megaparsec       >= 6.0  && < 7.0
                     , stache
                     , text             >= 1.2  && < 1.3
   other-modules:      Text.Mustache.Compile.THSpec
@@ -90,7 +90,7 @@ test-suite mustache-spec
                     , containers       >= 0.5  && < 0.6
                     , file-embed
                     , hspec            >= 2.0  && < 3.0
-                    , megaparsec       >= 5.0  && < 6.0
+                    , megaparsec       >= 6.0  && < 7.0
                     , stache
                     , text             >= 1.2  && < 1.3
                     , yaml             >= 0.8  && < 0.9
@@ -108,7 +108,7 @@ benchmark bench
                     , base             >= 4.7  && < 5.0
                     , criterion        >= 0.6.2.1 && < 1.3
                     , deepseq          >= 1.4  && < 1.5
-                    , megaparsec       >= 5.0  && < 6.0
+                    , megaparsec       >= 6.0  && < 7.0
                     , stache
                     , text             >= 1.2  && < 1.3
   if flag(dev)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
-resolver: lts-8.15
+resolver: lts-9.0
 packages:
 - '.'
+extra-deps:
+- hspec-megaparsec-1.0.0
+- megaparsec-6.0.0

--- a/tests/Text/Mustache/RenderSpec.hs
+++ b/tests/Text/Mustache/RenderSpec.hs
@@ -117,7 +117,7 @@ spec = describe "renderMustache" $ do
         it "skips non-empty list" $
           r nodes (object ["foo" .= [True]]) `shouldBe` ""
   context "when rendering a partial" $ do
-    let nodes = [ Partial "partial" (Just $ unsafePos 4)
+    let nodes = [ Partial "partial" (Just $ mkPos 4)
                 , TextBlock "*" ]
     it "skips missing partial" $
       r nodes Null `shouldBe` "   *"


### PR DESCRIPTION
Results so far:

* Switching input type from lazy `Text` to strict `Text` is necessary. No problem with that.
* The new design forces everything to be `Text` instead of the weird mix of `String` and `Text`. That's good.
* Performance: judging by "comprehensive template" benchmark, Megaparsec 6 so far is 43% faster for this parser than Megaparsec 5.