### PR TITLE
Add compileMustacheDirCustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## Stache 1.1.3
+## Stache 1.2.0
 
-* Added `compileMustacheDirCustom` that allows custom file extensions such as `.mush`
-* Updated to stackage 9.5, and Megaparsec 6.1.1
+* Added `compileMustacheDirCustom` that allows custom file extensions such as `.mush`.
+
+* Added `isMustacheFile`, a predicate for `.mustache` files.
 
 ## Stache 1.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Stache 1.2.0
 
-* Added `compileMustacheDirCustom` that allows custom file extensions such as `.mush`.
+* Added `compileMustacheDirCustom` that allows for a custom template predicate.
 
 * Added `isMustacheFile`, a predicate for `.mustache` files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Stache 1.1.3
+
+* Added `compileMustacheDirCustom` that allows custom file extensions such as `.mush`
+* Updated to stackage 9.5, and Megaparsec 6.1.1
+
 ## Stache 1.1.2
 
 * Fixed compilation of the test suite with Cabal 2.0/GHC 8.2.1.

--- a/Text/Mustache.hs
+++ b/Text/Mustache.hs
@@ -82,8 +82,10 @@ module Text.Mustache
   , displayMustacheWarning
     -- * Compiling
   , compileMustacheDir
+  , compileMustacheDirCustom
   , compileMustacheFile
   , compileMustacheText
+  , isMustacheFile
     -- * Rendering
   , renderMustache
   , renderMustacheW )

--- a/Text/Mustache/Compile.hs
+++ b/Text/Mustache/Compile.hs
@@ -15,6 +15,7 @@
 
 module Text.Mustache.Compile
   ( compileMustacheDir
+  , compileMustacheDirCustom
   , getMustacheFilesInDir
   , compileMustacheFile
   , compileMustacheText )

--- a/Text/Mustache/Compile.hs
+++ b/Text/Mustache/Compile.hs
@@ -131,7 +131,8 @@ getTemplateFilesInDir predicate path = liftIO $
   filterM (templateFilter predicate) . fmap (F.combine path) >>=
   mapM makeAbsolute
 
--- | Check if a given 'FilePath' points to a mustache file.
+-- | Check if a given 'FilePath' points to a template file
+-- useing a predicate.
 
 templateFilter :: (FilePath -> Bool) -> FilePath -> IO Bool
 templateFilter predicate path = do

--- a/stache.cabal
+++ b/stache.cabal
@@ -1,5 +1,5 @@
 name:                 stache
-version:              1.1.2
+version:              1.1.3
 cabal-version:        >= 1.18
 tested-with:          GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
 license:              BSD3

--- a/stache.cabal
+++ b/stache.cabal
@@ -1,5 +1,5 @@
 name:                 stache
-version:              1.1.3
+version:              1.1.2
 cabal-version:        >= 1.18
 tested-with:          GHC==7.8.4, GHC==7.10.3, GHC==8.0.2, GHC==8.2.1
 license:              BSD3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
-resolver: lts-9.0
+resolver: lts-9.5
 packages:
 - '.'
 extra-deps:
 - hspec-megaparsec-1.0.0
-- megaparsec-6.0.0
+- megaparsec-6.1.1


### PR DESCRIPTION
* adds compileMustacheDirCustom which allows arbitrary extension names for those who don't like to type out `.mustache`

* Bumps Stackage version to 9.5 & MegaParsec to 6.1.1 (Bugfixes only)
