### PR TITLE
Fix TH.compileMustacheDir' was not using predicate for pname.

### DIFF
--- a/Text/Mustache/Compile/TH.hs
+++ b/Text/Mustache/Compile/TH.hs
@@ -74,7 +74,7 @@ compileMustacheDir'
   -> Q Exp             -- ^ The resulting template
 compileMustacheDir' predicate pname path = do
   runIO (C.getMustacheFilesInDir' predicate path) >>= mapM_ addDependentFile
-  (runIO . try) (C.compileMustacheDir pname path) >>= handleEither
+  (runIO . try) (C.compileMustacheDir' predicate pname path) >>= handleEither
 
 -- | Compile single Mustache template and select it.
 --


### PR DESCRIPTION
Totally my fault, I did not notice during testing because I had not yet renamed my files to .mu and was thus using isMustacheFile as my predicate.