### PR TITLE
shows key source positions in renderer warnings

### DIFF
--- a/Text/Mustache.hs
+++ b/Text/Mustache.hs
@@ -85,6 +85,11 @@ module Text.Mustache
   , compileMustacheDir'
   , compileMustacheFile
   , compileMustacheText
+    -- * Compiling with additional error information on some renderer failures.
+  , compileMustacheDirWithLocs
+  , compileMustacheDirWithLocs'
+  , compileMustacheFileWithLocs
+  , compileMustacheTextWithLocs
     -- * Rendering
   , renderMustache
   , renderMustacheW )

--- a/Text/Mustache/Render.hs
+++ b/Text/Mustache/Render.hs
@@ -186,12 +186,12 @@ renderMany f (n:ns) = do
 -- | Lookup a 'Value' by its 'Key'.
 
 lookupKey :: Key -> Render Value
-lookupKey (Key []) = NE.head <$> asks rcContext
+lookupKey (Key [] _) = NE.head <$> asks rcContext
 lookupKey k = do
   v <- asks rcContext
   p <- asks rcPrefix
   let f x = asum (simpleLookup False (x <> k) <$> v)
-  case asum (fmap (f . Key) . reverse . tails $ unKey p) of
+  case asum (fmap (f . (flip Key Nothing)) . reverse . tails $ unKey p) of
     Nothing ->
       Null <$ tellWarning (MustacheVariableNotFound (p <> k))
     Just r ->
@@ -209,11 +209,11 @@ simpleLookup
   -> Key               -- ^ The key to lookup
   -> Value             -- ^ Source value
   -> Maybe Value       -- ^ Looked-up value
-simpleLookup _ (Key [])     obj        = return obj
-simpleLookup c (Key (k:ks)) (Object m) =
+simpleLookup _ (Key [] _)     obj        = return obj
+simpleLookup c (Key (k:ks) _) (Object m) =
   case H.lookup k m of
     Nothing -> if c then Just Null else Nothing
-    Just  v -> simpleLookup True (Key ks) v
+    Just  v -> simpleLookup True (Key ks Nothing) v
 simpleLookup _ _ _ = Nothing
 {-# INLINE simpleLookup #-}
 

--- a/stache.cabal
+++ b/stache.cabal
@@ -1,5 +1,5 @@
 name:                 stache
-version:              2.0.1
+version:              2.1.1
 cabal-version:        1.18
 tested-with:          GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.3
 license:              BSD3

--- a/tests/Text/Mustache/Compile/THSpec.hs
+++ b/tests/Text/Mustache/Compile/THSpec.hs
@@ -13,6 +13,7 @@ import Test.Hspec
 #if MIN_VERSION_template_haskell(2,11,0)
 import Data.Semigroup ((<>))
 import Text.Mustache.Type
+import Text.Megaparsec (SourcePos(..), mkPos)
 import qualified Data.Map                 as M
 import qualified Text.Mustache.Compile.TH as TH
 #endif
@@ -28,6 +29,11 @@ spec = do
       [TH.mustache|From Quasi-Quote!
 |]
         `shouldBe` qqTemplate
+  describe "mustacheWithLocs" $
+    it "compiles template using QuasiQuotes at compile time" $
+      [TH.mustacheWithLocs|Hello {{name}} from Quasi-Quote!
+|]
+        `shouldBe` qqWithLocTemplate
   describe "compileMustacheText" $
     it "compiles template from text at compile time" $
       $(TH.compileMustacheText "foo" "This is the ‘foo’.\n")
@@ -45,6 +51,12 @@ qqTemplate :: Template
 qqTemplate = Template "quasi-quoted" $
   M.singleton "quasi-quoted" [TextBlock "From Quasi-Quote!\n"]
 
+qqWithLocTemplate :: Template
+qqWithLocTemplate = Template "quasi-quoted" $
+    M.singleton "quasi-quoted" [ TextBlock "Hello "
+                               , EscapedVar (Key ["name"] (Just SourcePos { sourceName = "", sourceColumn = mkPos 9, sourceLine = mkPos 1}))
+                               , TextBlock " from Quasi-Quote!\n"]
+  
 fooTemplate :: Template
 fooTemplate = Template "foo" $
   M.singleton "foo" [TextBlock "This is the ‘foo’.\n"]

--- a/tests/Text/Mustache/ParserSpec.hs
+++ b/tests/Text/Mustache/ParserSpec.hs
@@ -11,52 +11,57 @@ import Test.Hspec.Megaparsec
 import Text.Megaparsec
 import Text.Mustache.Parser
 import Text.Mustache.Type
+import Data.Text (Text)
+import Data.Void (Void)
 
 main :: IO ()
 main = hspec spec
 
-spec :: Spec
-spec = describe "parseMustache" $ do
-  let p = parseMustache ""
-      key = Key . pure
+spec :: SpecWith ()
+spec = do
+  testsuite "parseMustache" (parseMustache "") (\name _ _ -> Key { unKey = pure name, keySourcePos = Nothing})
+  testsuite "parseMustacheWithPositions" (parseMustacheWithPositions "") (\name line col -> Key { unKey = pure name, keySourcePos = Just SourcePos { sourceName = "", sourceLine = mkPos line, sourceColumn = mkPos col}})
+  
+testsuite :: String -> (Text -> Either (ParseErrorBundle Text Void) [Node]) -> (Text -> Int -> Int -> Key) -> SpecWith ()
+testsuite title p key = describe title $ do
   it "parses text" $
     p "test12356p0--=-34{}jnv,\n"
       `shouldParse` [TextBlock "test12356p0--=-34{}jnv,\n"]
   context "when parsing a variable" $ do
     context "with white space" $ do
       it "parses escaped {{ variable }}" $
-        p "{{ name }}" `shouldParse` [EscapedVar (key "name")]
+        p "{{ name }}" `shouldParse` [EscapedVar (key "name" 1 4)]
       it "parses unescaped {{{ variable }}}" $
-        p "{{{ name }}}" `shouldParse` [UnescapedVar (key "name")]
+        p "{{{ name }}}" `shouldParse` [UnescapedVar (key "name" 1 5)]
       it "parses unescaped {{& variable }}" $
-        p "{{& name }}" `shouldParse` [UnescapedVar (key "name")]
+        p "{{& name }}" `shouldParse` [UnescapedVar (key "name" 1 5)]
     context "without white space" $ do
       it "parses escaped {{variable}}" $
-        p "{{name}}" `shouldParse` [EscapedVar (key "name")]
+        p "{{name}}" `shouldParse` [EscapedVar (key "name" 1 3)]
       it "parses unescaped {{{variable}}}" $
-        p "{{{name}}}" `shouldParse` [UnescapedVar (key "name")]
+        p "{{{name}}}" `shouldParse` [UnescapedVar (key "name" 1 4)]
       it "parses unescaped {{& variable }}" $
-        p "{{&name}}" `shouldParse` [UnescapedVar (key "name")]
+        p "{{&name}}" `shouldParse` [UnescapedVar (key "name" 1 4)]
     it "allows '-' in variable names" $
-      p "{{ var-name }}" `shouldParse` [EscapedVar (key "var-name")]
+      p "{{ var-name }}" `shouldParse` [EscapedVar (key "var-name" 1 4)]
     it "allows '_' in variable names" $
-      p "{{ var_name }}" `shouldParse` [EscapedVar (key "var_name")]
+      p "{{ var_name }}" `shouldParse` [EscapedVar (key "var_name" 1 4)]
   context "when parsing a section" $ do
     it "parses empty section" $
-      p "{{#section}}{{/section}}" `shouldParse` [Section (key "section") []]
+      p "{{#section}}{{/section}}" `shouldParse` [Section (key "section" 1 4) []]
     it "parses non-empty section" $
       p "{{# section }}Hi, {{name}}!\n{{/section}}" `shouldParse`
-        [Section (key "section")
+        [Section (key "section" 1 5)
          [ TextBlock "Hi, "
-         , EscapedVar (key "name")
+         , EscapedVar (key "name" 1 21)
          , TextBlock "!\n"]]
   context "when parsing an inverted section" $ do
     it "parses empty inverted section" $
       p "{{^section}}{{/section}}" `shouldParse`
-        [InvertedSection (key "section") []]
+        [InvertedSection (key "section" 1 4) []]
     it "parses non-empty inverted section" $
       p "{{^ section }}No one here?!\n{{/section}}" `shouldParse`
-        [InvertedSection (key "section") [TextBlock "No one here?!\n"]]
+        [InvertedSection (key "section" 1 5) [TextBlock "No one here?!\n"]]
   context "when parsing a partial" $ do
     it "parses a partial with white space" $
       p "{{> that-s_my-partial }}" `shouldParse`
@@ -70,19 +75,19 @@ spec = describe "parseMustache" $ do
   context "when running into delimiter change" $ do
     it "has effect" $
       p "{{=<< >>=}}<<var>>{{var}}" `shouldParse`
-        [EscapedVar (key "var"), TextBlock "{{var}}"]
+        [EscapedVar (key "var" 1 14), TextBlock "{{var}}"]
     it "handles whitespace just as well" $
       p "{{=<<   >>=}}<<  var >>{{ var  }}" `shouldParse`
-        [EscapedVar (key "var"), TextBlock "{{ var  }}"]
+        [EscapedVar (key "var" 1 18), TextBlock "{{ var  }}"]
     it "affects {{{s" $
       p "{{=<< >>=}}<<{var}>>" `shouldParse`
-        [UnescapedVar (key "var")]
+        [UnescapedVar (key "var" 1 15)]
     it "parses two subsequent delimiter changes" $
       p "{{=(( ))=}}(( var ))((=-- $-=))--#section$---/section$-" `shouldParse`
-        [EscapedVar (key "var"), Section (key "section") []]
+        [EscapedVar (key "var" 1 15), Section (key "section" 1 35) []]
     it "propagates delimiter change from a nested scope" $
       p "{{#section}}{{=<< >>=}}<</section>><<var>>" `shouldParse`
-        [Section (key "section") [], EscapedVar (key "var")]
+        [Section (key "section" 1 4) [], EscapedVar (key "var" 1 38)]
   context "when given malformed input" $ do
     it "rejects unclosed tags" $ do
       let s = "{{ name "

--- a/tests/Text/Mustache/RenderSpec.hs
+++ b/tests/Text/Mustache/RenderSpec.hs
@@ -24,7 +24,7 @@ spec = describe "renderMustache" $ do
       r ns value =
         let template = Template "test" (M.singleton "test" ns)
         in renderMustache template value
-      key = Key . pure
+      key name = Key { unKey = pure name, keySourcePos = Nothing }
   it "leaves text block “as is”" $
     r [TextBlock "a text block"] Null `shouldBe` "a text block"
   it "renders escaped variables correctly" $
@@ -91,7 +91,7 @@ spec = describe "renderMustache" $ do
             (object ["foo" .= (5 :: Int)])
             `shouldBe` "brr"
         it "uses the key as context" $
-          r [Section (key "foo") [EscapedVar (Key [])]]
+          r [Section (key "foo") [EscapedVar (Key [] Nothing)]]
             (object ["foo" .= (5 :: Int)])
             `shouldBe` "5"
       context "when the key is a non-empty string" $ do
@@ -100,7 +100,7 @@ spec = describe "renderMustache" $ do
             (object ["foo" .= ("x" :: Text)])
             `shouldBe` "brr"
         it "uses the key as context" $
-          r [Section (key "foo") [EscapedVar (Key [])]]
+          r [Section (key "foo") [EscapedVar (Key [] Nothing)]]
             (object ["foo" .= ("x" :: Text)])
             `shouldBe` "x"
   context "when rendering an inverted section" $ do
@@ -141,7 +141,7 @@ spec = describe "renderMustache" $ do
   context "when using dotted keys inside a section" $
     it "it should be equivalent to access via one more section" $
       r [ Section (key "things")
-          [ EscapedVar (Key ["atts", "color"])
+          [ EscapedVar (Key ["atts", "color"] Nothing)
           , TextBlock " == "
           , Section (key "atts") [EscapedVar (key "color")] ] ]
         (object ["things" .=

--- a/tests/Text/Mustache/TypeSpec.hs
+++ b/tests/Text/Mustache/TypeSpec.hs
@@ -8,6 +8,7 @@ where
 import Data.Semigroup ((<>))
 import Test.Hspec
 import Text.Mustache.Type
+import Text.Megaparsec.Pos (SourcePos(..), pos1)
 import qualified Data.Map as M
 
 main :: IO ()
@@ -29,18 +30,21 @@ spec = do
   describe "showKey" $ do
     context "when the key has no elements in it" $
       it "is rendered correctly" $
-        showKey (Key []) `shouldBe` "<implicit>"
+        showKey (Key [] Nothing) `shouldBe` "<implicit>"
     context "when the key has some elements" $
       it "is rendered correctly" $ do
-        showKey (Key ["boo"]) `shouldBe` "boo"
-        showKey (Key ["foo","bar"]) `shouldBe` "foo.bar"
-        showKey (Key ["baz","baz","quux"]) `shouldBe` "baz.baz.quux"
+        showKey (Key ["boo"] Nothing) `shouldBe` "boo"
+        showKey (Key ["foo","bar"] Nothing) `shouldBe` "foo.bar"
+        showKey (Key ["baz","baz","quux"] Nothing) `shouldBe` "baz.baz.quux"
   describe "displayMustacheWarning" $ do
     it "renders “not found” warning correctly" $
-      displayMustacheWarning (MustacheVariableNotFound (Key ["foo"]))
+      displayMustacheWarning (MustacheVariableNotFound (Key ["foo"] Nothing))
         `shouldBe` "Referenced value was not provided, key: foo"
+    it "renders “not found” warning correctly if we still have position information" $
+      displayMustacheWarning (MustacheVariableNotFound (Key ["foo"] (Just SourcePos {sourceName = "<implicit>", sourceLine = pos1, sourceColumn = pos1})))
+        `shouldBe` "Referenced value was not provided, key: foo, position in template: <implicit>:1:1"
     it "renders “directly rendered value” warning correctly" $
-      displayMustacheWarning (MustacheDirectlyRenderedValue (Key ["foo"]))
+      displayMustacheWarning (MustacheDirectlyRenderedValue (Key ["foo"] Nothing))
         `shouldBe` "Complex value rendered as such, key: foo"
 
 templateA :: Template


### PR DESCRIPTION
Hi there,

thats more of an RFC than a PR.

I would really like to see the position of a key in a `MustacheWarning` to have an easier time
developing medium to bigger sized templates.

So I tried to implement that myself, but as I am still a starting haskeller, some of my decisions might
not be the best.

As the `getSourcePos` function is advertised as being slow, I thought the user might like to have a choice,
if they either want to parse their templates fast or if they want to have better error messages in case of a renderer failure.

So I went with duplicating the API, which is ugly, I admit.
Some alternatives I could think of:
1. Use a different `Template` type and use return type polymorphism to select which parsing variant is choosen. I wouldn't know how to handle the template haskell api in this style. Maybe it could be mixed? Return type polymorphism for the non-template haskell api and duplicating the api for template haskell?
2. Simply record the source position information always. Some timings from the benchmark on my machine:
    * `parser/text with escaped var` 10.87 microns
    * `parserWithLocs/text with escaped var` 11.66 microns
    * `parser/comprehensive template` 117.6 microns
    * `parserWithLocs/comprehensive template` 123.8 microns

    So it is a ~8 % performance decrease. I would think, that might be acceptable, but I don't know your performance needs or of the overall user base.

What are your thoughts?