### PR TITLE
fix off-by-one error in addIndents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Fixed the bug related to incorrect indentation with nested partials.
+  [Issue 44](https://github.com/stackbuilders/stache/issues/44).
+
 * Dropped support for GHC 8.2 and older.
 
 ## Stache 2.1.0

--- a/Text/Mustache/Render.hs
+++ b/Text/Mustache/Render.hs
@@ -26,12 +26,11 @@ import Data.Foldable (asum)
 import Data.List (tails)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Text (Text)
-import Text.Megaparsec.Pos (Pos, unPos)
+import Text.Megaparsec.Pos (Pos, mkPos, unPos)
 import Text.Mustache.Type
 import qualified Data.HashMap.Strict     as H
 import qualified Data.List.NonEmpty      as NE
 import qualified Data.Map                as M
-import qualified Data.Semigroup          as S
 import qualified Data.Text               as T
 import qualified Data.Text.Lazy          as TL
 import qualified Data.Text.Lazy.Builder  as B
@@ -254,7 +253,7 @@ addIndents :: Maybe Pos -> Maybe Pos -> Maybe Pos
 addIndents Nothing  Nothing  = Nothing
 addIndents Nothing  (Just x) = Just x
 addIndents (Just x) Nothing  = Just x
-addIndents (Just x) (Just y) = Just (x S.<> y)
+addIndents (Just x) (Just y) = Just (mkPos $ unPos x + unPos y - 1)
 {-# INLINE addIndents #-}
 
 -- | Build indentation of specified length by repeating the space character.

--- a/tests/Text/Mustache/RenderSpec.hs
+++ b/tests/Text/Mustache/RenderSpec.hs
@@ -138,6 +138,14 @@ spec = describe "renderMustache" $ do
                        , ("partial", [TextBlock "one\ntwo\nthree"]) ]
       in renderMustache template Null `shouldBe`
            "   one\n   two\n   three*"
+  context "when rendering a nested partial" $
+    it "renders outer partial correctly" $
+      let template = Template "outer" $
+            M.fromList [ ("inner",  [TextBlock "x"])
+                       , ("middle", [Partial "inner"  (Just $ mkPos 1)])
+                       , ("outer",  [Partial "middle" (Just $ mkPos 1)])
+                       ]
+      in renderMustache template Null `shouldBe` "x"
   context "when using dotted keys inside a section" $
     it "it should be equivalent to access via one more section" $
       r [ Section (key "things")


### PR DESCRIPTION
Close #44.

Fixes an apparent off-by-one error in [`addIndents`](https://github.com/stackbuilders/stache/blob/master/Text/Mustache/Render.hs#L253) - megaparsec `Pos` values start from 1, not 0.