### PR TITLE
Allow text-2.0

### DIFF
--- a/stache.cabal
+++ b/stache.cabal
@@ -51,7 +51,7 @@ library
         megaparsec >=7.0 && <10.0,
         mtl >=2.1 && <3.0,
         template-haskell >=2.11 && <2.19,
-        text >=1.2 && <1.3,
+        text >=1.2 && <2.1,
         vector >=0.11 && <0.13
 
     if flag(dev)
@@ -76,7 +76,7 @@ executable stache
         gitrev >=1.3 && <1.4,
         optparse-applicative >=0.14 && <0.18,
         stache,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         yaml >=0.8 && <0.12,
         filepath >=1.2 && <1.5
 
@@ -109,7 +109,7 @@ test-suite tests
         megaparsec >=7.0 && <10.0,
         stache,
         template-haskell >=2.11 && <2.19,
-        text >=1.2 && <1.3
+        text >=1.2 && <2.1
 
     if flag(dev)
         ghc-options: -O0 -Wall -Werror
@@ -131,7 +131,7 @@ test-suite mustache-spec
         hspec >=2.0 && <3.0,
         megaparsec >=7.0 && <10.0,
         stache,
-        text >=1.2 && <1.3,
+        text >=1.2 && <2.1,
         yaml >=0.8 && <0.12
 
     if flag(dev)
@@ -152,7 +152,7 @@ benchmark bench
         deepseq >=1.4 && <1.5,
         megaparsec >=7.0 && <10.0,
         stache,
-        text >=1.2 && <1.3
+        text >=1.2 && <2.1
 
     if flag(dev)
         ghc-options: -O2 -Wall -Werror


### PR DESCRIPTION
Tested with

    cabal test --constraint='text>=2' -w ghc-9.2.2
