### PR TITLE
Include Paths_stache in autogen-modules

### DIFF
--- a/stache.cabal
+++ b/stache.cabal
@@ -69,6 +69,7 @@ executable stache
     main-is:          Main.hs
     hs-source-dirs:   app
     other-modules:    Paths_stache
+    autogen-modules:  Paths_stache
     default-language: Haskell2010
     build-depends:
         aeson >=2 && <3,


### PR DESCRIPTION
As per Cabal guidelines for cabal-version: 2.0.